### PR TITLE
Introduce timezone to time:currentTimestamp function

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -100,6 +100,9 @@
                             org.wso2.extension.siddhi.execution.time.*
                         </Export-Package>
                         <Import-Package>
+                            org.wso2.siddhi.core.*; version="${siddhi.version.range}",
+                            org.wso2.siddhi.query.*; version="${siddhi.version.range}",
+                            org.wso2.siddhi.annotation.*; version="${siddhi.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <Include-Resource>

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/time/CurrentTimestampFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/time/CurrentTimestampFunctionExtension.java
@@ -25,16 +25,22 @@ import org.wso2.siddhi.annotation.Extension;
 import org.wso2.siddhi.annotation.ReturnAttribute;
 import org.wso2.siddhi.annotation.util.DataType;
 import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.executor.ExpressionExecutor;
 import org.wso2.siddhi.core.executor.function.FunctionExecutor;
 import org.wso2.siddhi.core.util.config.ConfigReader;
 import org.wso2.siddhi.query.api.definition.Attribute;
+import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Map;
 
 /**
- * currentTimestamp()
+ * currentTimestamp() or currentTimestamp(<time-zone>)
  * Returns System Time in yyyy-MM-dd HH:mm:ss format.
  * Return Type(s): STRING
  */
@@ -45,19 +51,41 @@ import java.util.Map;
 @Extension(
         name = "currentTimestamp",
         namespace = "time",
-        description = "This function returns the system time in 'yyyy-MM-dd HH:mm:ss' format.",
+        description = "If no argument is provided, this function will return the currentSystemTime and if the " +
+                "timezone is provided as an argument, it will convert the current systemtime to the given timezone " +
+                "and return. This function returns time in 'yyyy-MM-dd HH:mm:ss' format.\n" +
+                "To check the available timezone ids, visit " +
+                "https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html",
         returnAttributes = @ReturnAttribute(
                 description = "The value returned is of 'string' type.",
                 type = {DataType.STRING}),
         examples = {
                 @Example(
                         syntax = "define stream InputStream (symbol string, price long, volume long);\n" +
-                                 "from InputStream " +
+                                "from InputStream " +
                                 "select symbol , time:currentTimestamp() as currentTimestamp\n" +
-                                 "insert into OutputStream;",
+                                "insert into OutputStream;",
                         description = "This query returns, symbol from the 'InputStream' and "
                                 + "the current time stamp of the system in 'yyyy-MM-dd HH:mm:ss' format"
                                 + " as 'currentTimestamp', to the 'OutputStream'."
+                ),
+                @Example(
+                        syntax = "define stream InputStream (symbol string, price long, volume long);\n" +
+                                "from InputStream " +
+                                "select symbol , time:currentTimestamp(\"Asia/Kolkata\") as currentTimestamp\n" +
+                                "insert into OutputStream;",
+                        description = "This query returns, symbol from the 'InputStream' and "
+                                + "the current time stamp of the system which is converted to Asia/Kolkata timezone, " +
+                                "in 'yyyy-MM-dd HH:mm:ss' format as 'currentTimestamp', to the 'OutputStream'."
+                ),
+                @Example(
+                        syntax = "define stream InputStream (symbol string, price long, volume long);\n" +
+                                "from InputStream " +
+                                "select symbol , time:currentTimestamp(\"CST\") as currentTimestamp\n" +
+                                "insert into OutputStream;",
+                        description = "This query returns, symbol from the 'InputStream' and "
+                                + "the current time stamp of the system which is converted to CST timezone, in " +
+                                "'yyyy-MM-dd HH:mm:ss' format as 'currentTimestamp', to the 'OutputStream'."
                 )
         }
 )
@@ -65,24 +93,43 @@ public class CurrentTimestampFunctionExtension extends FunctionExecutor {
 
     private Attribute.Type returnType = Attribute.Type.STRING;
     private FastDateFormat dateFormat = null;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern(TimeExtensionConstants.EXTENSION_TIME_CURRENT_TIMESTAMP_FORMAT);
 
     @Override
     protected void init(ExpressionExecutor[] expressionExecutors, ConfigReader configReader,
                         SiddhiAppContext siddhiAppContext) {
+        if (expressionExecutors.length > 1) {
+            throw new SiddhiAppValidationException("Invalid no of arguments passed to time:currentTimestamp function," +
+                    "required 0 or 1, but found " + expressionExecutors.length);
+        }
+
+        if (expressionExecutors.length == 1 && expressionExecutors[0].getReturnType() != Attribute.Type.STRING) {
+            throw new SiddhiAppValidationException("Invalid parameter type found for the argument of " +
+                    "time:currentTimestamp function, " + "required " + Attribute.Type.STRING + " but found " +
+                    attributeExpressionExecutors[0].getReturnType().toString());
+        }
         dateFormat = FastDateFormat.getInstance(TimeExtensionConstants.EXTENSION_TIME_CURRENT_TIMESTAMP_FORMAT);
     }
 
     @Override
     protected Object execute(Object[] data) {
-        return null; //Since the e function takes in no parameters, this method does not get called. Hence,
-        // not implemented.
+        return null;
     }
 
     @Override
     protected Object execute(Object data) {
-        Date now = new Date();
-        return dateFormat.format(now);
-
+        if (data == null) {
+            return dateFormat.format(new Date());
+        } else {
+            try {
+                ZoneId zoneId = ZoneId.of((String) data, ZoneId.SHORT_IDS);
+                ZonedDateTime convertedTime = ZonedDateTime.now().withZoneSameInstant(zoneId);
+                return convertedTime.format(DATE_TIME_FORMATTER);
+            } catch (DateTimeException e) {
+                throw new SiddhiAppRuntimeException("Provided time zone " + data + " is invalid.", e);
+            }
+        }
     }
 
     @Override

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/time/CurrentTimestampFunctionExtensionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/time/CurrentTimestampFunctionExtensionTestCase.java
@@ -47,7 +47,7 @@ public class CurrentTimestampFunctionExtensionTestCase {
     }
 
     @Test
-    public void currentTimestampFunctionExtension() throws InterruptedException {
+    public void testCurrentTimestampFunctionExtension1() throws InterruptedException {
 
         log.info("CurrentTimestampFunctionExtensionTestCase");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -56,6 +56,87 @@ public class CurrentTimestampFunctionExtensionTestCase {
                 "define stream inputStream (symbol string, price long, volume long);";
         String query = ("@info(name = 'query1') " +
                 "from inputStream select symbol , time:currentTimestamp() as currentTimestamp " +
+                "insert into outputStream;");
+        SiddhiAppRuntime executionPlanRuntime = siddhiManager
+                .createSiddhiAppRuntime(inStreamDefinition + query);
+
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+
+                eventArrived = true;
+                for (Event inEvent : inEvents) {
+                    eventCount.incrementAndGet();
+                    log.info("Event : " + eventCount.get() + ",currentTimestamp : " + inEvent.getData(1));
+
+                }
+            }
+        });
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+        inputHandler.send(new Object[]{"IBM", 700f, 100L});
+        inputHandler.send(new Object[]{"WSO2", 60.5f, 200L});
+        inputHandler.send(new Object[]{"XYZ", 60.5f, 200L});
+
+        SiddhiTestHelper.waitForEvents(waitTime, 3, eventCount, timeout);
+        AssertJUnit.assertEquals(3, eventCount.get());
+        AssertJUnit.assertTrue(eventArrived);
+        executionPlanRuntime.shutdown();
+    }
+
+
+    @Test
+    public void tesCurrentTimestampFunctionExtension2() throws InterruptedException {
+
+        log.info("CurrentTimestampFunctionExtensionTestCase");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "" +
+                "define stream inputStream (symbol string, price long, volume long);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream select symbol , time:currentTimestamp(\"CST\") as currentTimestamp " +
+                "insert into outputStream;");
+        SiddhiAppRuntime executionPlanRuntime = siddhiManager
+                .createSiddhiAppRuntime(inStreamDefinition + query);
+
+        executionPlanRuntime.addCallback("query1", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+
+                eventArrived = true;
+                for (Event inEvent : inEvents) {
+                    eventCount.incrementAndGet();
+                    log.info("Event : " + eventCount.get() + ",currentTimestamp : " + inEvent.getData(1));
+
+                }
+            }
+        });
+
+        InputHandler inputHandler = executionPlanRuntime.getInputHandler("inputStream");
+        executionPlanRuntime.start();
+        inputHandler.send(new Object[]{"IBM", 700f, 100L});
+        inputHandler.send(new Object[]{"WSO2", 60.5f, 200L});
+        inputHandler.send(new Object[]{"XYZ", 60.5f, 200L});
+
+        SiddhiTestHelper.waitForEvents(waitTime, 3, eventCount, timeout);
+        AssertJUnit.assertEquals(3, eventCount.get());
+        AssertJUnit.assertTrue(eventArrived);
+        executionPlanRuntime.shutdown();
+    }
+
+    @Test
+    public void tesCurrentTimestampFunctionExtension3() throws InterruptedException {
+
+        log.info("CurrentTimestampFunctionExtensionTestCase");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String inStreamDefinition = "" +
+                "define stream inputStream (symbol string, price long, volume long);";
+        String query = ("@info(name = 'query1') " +
+                "from inputStream select symbol , time:currentTimestamp(\"Asia/Kolkata\") as currentTimestamp " +
                 "insert into outputStream;");
         SiddhiAppRuntime executionPlanRuntime = siddhiManager
                 .createSiddhiAppRuntime(inStreamDefinition + query);

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
     <properties>
         <siddhi.version>4.4.8</siddhi.version>
+        <siddhi.version.range>[4.0.0, 5.0.0)</siddhi.version.range>
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.8</testng.version>


### PR DESCRIPTION
## Purpose
> Introduce timezone to time:currentTimestamp function

## Goals
This allows providing timezone as an argument to `time:currentTimestamp()` function. Then it converts the current system time to the given time zone and returns in `yyyy-MM-dd HH:mm:ss` format.

Eg:
```
define stream InputStream (symbol string, price long, volume long);
from InputStream
select symbol , time:currentTimestamp() as currentTimestamp
insert into OutputStream;
```
This query returns, symbol from the 'InputStream' and the current timestamp of the system in `yyyy-MM-dd HH:mm:ss` format as `currentTimestamp`, to the 'OutputStream'.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
