### PR TITLE
Fix https://github.com/siddhi-io/siddhi-execution-time/issues/58

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/time/DateAddFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/time/DateAddFunctionExtension.java
@@ -252,19 +252,12 @@ public class DateAddFunctionExtension extends FunctionExecutor {
 
         if (data.length == 4 || useDefaultDateFormat) {
             try {
-                if (data[0] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to time:dateAdd(date,expr," +
-                            "unit,dateFormat) function" + ". First " +
-                            "argument cannot be null");
-                }
-                if (data[1] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to time:dateAdd(date,expr," +
-                            "unit,dateFormat) function" + ". Second " + "argument cannot be null");
+                if (data[0] == null || data[1] == null) {
+                    return null;
                 }
                 if (!useDefaultDateFormat) {
                     if (data[3] == null) {
-                        throw new SiddhiAppRuntimeException("Invalid input given to time:dateAdd(date,expr," +
-                                "unit,dateFormat) function" + ". Fourth " + "argument cannot be null");
+                        return null;
                     }
                     dateFormat = (String) data[3];
                 }
@@ -287,17 +280,8 @@ public class DateAddFunctionExtension extends FunctionExecutor {
 
         } else if (data.length == 3) {
 
-            if (data[0] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to time:dateAdd(timestampInMilliseconds," +
-                        "expr,unit) function" + ". First " + "argument cannot be null");
-            }
-            if (data[1] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to time:dateAdd(timestampInMilliseconds," +
-                        "expr,unit) function" + ". Second " + "argument cannot be null");
-            }
-            if (data[2] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to time:dateAdd(timestampInMilliseconds," +
-                        "expr,unit) function" + ". Third " + "argument cannot be null");
+            if (data[0] == null || data[1] == null || data[2] == null) {
+                return null;
             }
 
             try {

--- a/component/src/main/java/io/siddhi/extension/execution/time/DateDifferenceFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/time/DateDifferenceFunctionExtension.java
@@ -255,26 +255,13 @@ public class DateDifferenceFunctionExtension extends FunctionExecutor {
 
         if (data.length == 4 || useDefaultDateFormat) {
             try {
-                if (data[0] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to time:dateDiff(dateValue1," +
-                            "dateValue2,dateFormat1,dateFormat2) function" + ". " +
-                            "First " + "argument cannot be null");
-                }
-                if (data[1] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to time:dateDiff(dateValue1," +
-                            "dateValue2,dateFormat1,dateFormat2) function" + ". Second " + "argument cannot be null");
+                if (data[0] == null || data[1] == null) {
+                    return null;
                 }
 
                 if (!useDefaultDateFormat) {
-                    if (data[2] == null) {
-                        throw new SiddhiAppRuntimeException("Invalid input given to time:dateDiff(dateValue1," +
-                                "dateValue2,dateFormat1,dateFormat2) function" + ". " +
-                                "Third " + "argument cannot be null");
-                    }
-                    if (data[3] == null) {
-                        throw new SiddhiAppRuntimeException("Invalid input given to time:dateDiff(dateValue1," +
-                                "dateValue2,dateFormat1,dateFormat2) function" + ". " +
-                                "Fourth " + "argument cannot be null");
+                    if (data[2] == null || data[3] == null) {
+                        return null;
                     }
                     firstDateFormat = (String) data[2];
                     secondDateFormat = (String) data[3];
@@ -311,15 +298,8 @@ public class DateDifferenceFunctionExtension extends FunctionExecutor {
 
         } else if (data.length == 2) {
 
-            if (data[0] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to time:dateDiff" +
-                        "(timestampInMilliseconds1,timestampInMilliseconds2) function" + ". First " +
-                        "argument cannot be null");
-            }
-            if (data[1] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to time:dateDiff" +
-                        "(timestampInMilliseconds1,timestampInMilliseconds2) function" + ". Second " +
-                        "argument cannot be null");
+            if (data[0] == null || data[1] == null) {
+                return null;
             }
 
             try {

--- a/component/src/main/java/io/siddhi/extension/execution/time/DateFormatFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/time/DateFormatFunctionExtension.java
@@ -208,18 +208,12 @@ public class DateFormatFunctionExtension extends FunctionExecutor {
             FastDateFormat userSpecifiedSourceFormat;
 
             try {
-                if (data[0] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to time:dateFormat(dateValue," +
-                            "dateTargetFormat,dateSourceFormat) function" + ". First " + "argument cannot be null");
-                }
-                if (data[1] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to time:dateFormat(dateValue," +
-                            "dateTargetFormat,dateSourceFormat) function" + ". Second " + "argument cannot be null");
+                if (data[0] == null || data[1] == null) {
+                    return null;
                 }
                 if (!useDefaultDateFormat) {
                     if (data[2] == null) {
-                        throw new SiddhiAppRuntimeException("Invalid input given to time:dateFormat(dateValue," +
-                                "dateTargetFormat,dateSourceFormat) function" + ". Third " + "argument cannot be null");
+                        return null;
                     }
                     sourceDateFormat = (String) data[2];
                 }
@@ -241,13 +235,8 @@ public class DateFormatFunctionExtension extends FunctionExecutor {
             }
         } else if (data.length == 2) {
 
-            if (data[0] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to dateFormat(timestampInMilliseconds," +
-                        "dateTargetFormat) function" + ". First " + "argument cannot be null");
-            }
-            if (data[1] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to dateFormat(timestampInMilliseconds," +
-                        "dateTargetFormat) function" + ". Second " + "argument cannot be null");
+            if (data[0] == null || data[1] == null) {
+                return null;
             }
 
             // Format the Date to specified Format

--- a/component/src/main/java/io/siddhi/extension/execution/time/DateSubFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/time/DateSubFunctionExtension.java
@@ -281,21 +281,12 @@ public class DateSubFunctionExtension extends FunctionExecutor {
 
         if (data.length == 4 || useDefaultDateFormat) {
             try {
-                if (data[0] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to str:dateSub(date,expr," +
-                            "unit,dateFormat) function" + ". First " +
-                            "argument cannot be null");
-                }
-                if (data[1] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to str:dateSub(date,expr," +
-                            "unit,dateFormat) function" + ". Second " +
-                            "argument cannot be null");
+                if (data[0] == null || data[1] == null) {
+                    return null;
                 }
                 if (!useDefaultDateFormat) {
                     if (data[3] == null) {
-                        throw new SiddhiAppRuntimeException("Invalid input given to str:dateSub(date,expr," +
-                                "unit,dateFormat) function" + ". Fourth " +
-                                "argument cannot be null");
+                        return null;
                     }
                     dateFormat = (String) data[3];
                 }
@@ -319,18 +310,8 @@ public class DateSubFunctionExtension extends FunctionExecutor {
 
         } else if (data.length == 3) {
 
-            if (data[0] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to time:dateSub(timestampInMilliseconds," +
-                        "expr,unit) function" + ". First " + "argument cannot be null");
-            }
-            if (data[1] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to time:dateSub(timestampInMilliseconds," +
-                        "expr,unit) function" + ". Second " +
-                        "argument cannot be null");
-            }
-            if (data[2] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to time:dateSub(timestampInMilliseconds," +
-                        "expr,unit) function" + ". Third " + "argument cannot be null");
+            if (data[0] == null || data[1] == null || data[2] == null) {
+                return null;
             }
 
             try {

--- a/component/src/main/java/io/siddhi/extension/execution/time/ExtractAttributesFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/time/ExtractAttributesFunctionExtension.java
@@ -137,7 +137,6 @@ public class ExtractAttributesFunctionExtension extends FunctionExecutor {
     private String dateFormat = null;
     private Calendar cal = Calendar.getInstance();
     private String unit = null;
-    private boolean isLocaleDefined = false;
     private boolean useTimestampInMilliseconds = false;
     private Locale locale = null;
 
@@ -180,7 +179,6 @@ public class ExtractAttributesFunctionExtension extends FunctionExecutor {
         }
 
         if (locale != null) {
-            isLocaleDefined = true;
             cal = Calendar.getInstance(locale);
         } else {
             cal = Calendar.getInstance();
@@ -195,27 +193,11 @@ public class ExtractAttributesFunctionExtension extends FunctionExecutor {
         if ((data.length == 3 || data.length == 4 || useDefaultDateFormat) && !useTimestampInMilliseconds) {
             try {
                 if (data[1] == null) {
-                    if (isLocaleDefined) {
-                        throw new SiddhiAppRuntimeException("Invalid input given to time:extract(unit,dateValue," +
-                                "dateFormat, locale) function" + ". Second " +
-                                "argument cannot be null");
-                    } else {
-                        throw new SiddhiAppRuntimeException("Invalid input given to time:extract(unit,dateValue," +
-                                "dateFormat) function" + ". Second " +
-                                "argument cannot be null");
-                    }
+                    return null;
                 }
                 if (!useDefaultDateFormat) {
                     if (data[2] == null) {
-                        if (isLocaleDefined) {
-                            throw new SiddhiAppRuntimeException("Invalid input given to time:extract(unit,dateValue," +
-                                    "dateFormat, locale) function" + ". Third " +
-                                    "argument cannot be null");
-                        } else {
-                            throw new SiddhiAppRuntimeException("Invalid input given to time:extract(unit,dateValue," +
-                                    "dateFormat) function" + ". Third " +
-                                    "argument cannot be null");
-                        }
+                        return null;
                     }
                     dateFormat = (String) data[2];
                 }
@@ -235,14 +217,7 @@ public class ExtractAttributesFunctionExtension extends FunctionExecutor {
             }
         } else {
             if (data[0] == null) {
-                if (isLocaleDefined) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to time:extract(timestampInMilliseconds," +
-                            "unit, locale) function" + ". First " + "argument cannot be null");
-
-                } else {
-                    throw new SiddhiAppRuntimeException("Invalid input given to time:extract(timestampInMilliseconds," +
-                            "unit) function" + ". First " + "argument cannot be null");
-                }
+                return null;
             }
             try {
                 long millis = (Long) data[0];

--- a/component/src/main/java/io/siddhi/extension/execution/time/ExtractDateFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/time/ExtractDateFunctionExtension.java
@@ -132,14 +132,11 @@ public class ExtractDateFunctionExtension extends FunctionExecutor {
     protected Object execute(Object[] data, State state) {
         String userFormat;
         if (data[0] == null) {
-            throw new SiddhiAppRuntimeException("Invalid input given to time:date(dateValue," +
-                    "dateFormat) function" + ". First " + "argument cannot be null");
+            return null;
         }
         if (data.length > 0) {
             if (data[1] == null) {
-                throw new SiddhiAppRuntimeException(
-                        "Invalid input given to time:date(dateValue,dateFormat) function" + ". Second " +
-                                "argument cannot be null");
+                return null;
             }
             userFormat = (String) data[1];
         } else {

--- a/component/src/main/java/io/siddhi/extension/execution/time/ExtractDayOfWeekFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/time/ExtractDayOfWeekFunctionExtension.java
@@ -136,14 +136,11 @@ public class ExtractDayOfWeekFunctionExtension extends FunctionExecutor {
     protected Object execute(Object[] data, State state) {
         String userFormat;
         if (data[0] == null) {
-            throw new SiddhiAppRuntimeException("Invalid input given to time:dayOfWeek(dateValue," +
-                    "dateFormat) function" + ". First " + "argument cannot be null");
+            return null;
         }
         if (data.length > 1) {
             if (data[1] == null) {
-                throw new SiddhiAppRuntimeException(
-                        "Invalid input given to time:dayOfWeek(dateValue,dateFormat) function" + ". Second " +
-                                "argument cannot be null");
+                return null;
             } else {
                 userFormat = (String) data[1];
             }
@@ -172,8 +169,7 @@ public class ExtractDayOfWeekFunctionExtension extends FunctionExecutor {
     protected Object execute(Object data, State state) {
         String userFormat;
         if (data == null) {
-            throw new SiddhiAppRuntimeException("Invalid input given to time:dayOfWeek(dateValue," +
-                    "dateFormat) function" + ". First " + "argument cannot be null");
+            return null;
         }
         userFormat = TimeExtensionConstants.EXTENSION_TIME_DEFAULT_DATE_FORMAT;
         String source;

--- a/component/src/main/java/io/siddhi/extension/execution/time/TimestampInMillisecondsFunctionExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/time/TimestampInMillisecondsFunctionExtension.java
@@ -155,15 +155,11 @@ public class TimestampInMillisecondsFunctionExtension extends FunctionExecutor {
 
         if (data.length == 2) {
             if (data[0] == null) {
-                throw new SiddhiAppRuntimeException("Invalid input given to " +
-                        "time:timestampInMilliseconds(dateValue," +
-                        "dateFormat) function" + ". First argument cannot be null");
+                return null;
             }
             if (!useDefaultDateFormat) {
                 if (data[1] == null) {
-                    throw new SiddhiAppRuntimeException("Invalid input given to " +
-                            "time:timestampInMilliseconds(dateValue," +
-                            "dateFormat) function" + ". First argument cannot be null");
+                    return null;
                 }
                 dateFormat = (String) data[1];
             }

--- a/component/src/test/java/io/siddhi/extension/execution/time/DateAddFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/time/DateAddFunctionExtensionTestCase.java
@@ -150,9 +150,6 @@ public class DateAddFunctionExtensionTestCase {
     public void dateAddFunctionExtension5() throws InterruptedException {
 
         log.info("DateAddFunctionExtensionTestCaseFirstArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = ""
@@ -169,15 +166,20 @@ public class DateAddFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents[0].getData(0).toString().equals("IBM")) {
+                    AssertJUnit.assertNull(inEvents[0].getData(1));
+                }
+                if (inEvents[0].getData(0).toString().equals("WSO2")) {
+                    AssertJUnit.assertEquals("2012-05-11 13:23:44", inEvents[0].getData(1));
+                    AssertJUnit.assertEquals("2010-07-11 13:23:44", inEvents[0].getData(2));
+                    AssertJUnit.assertEquals("1415699624000", inEvents[0].getData(3));
+                }
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", null, "yyyy-MM-dd HH:mm:ss", 1415692424000L, 2 });
-        inputHandler.send(new Object[] { "IBM", "2010-05-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, 2 });
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateAdd("
-                                                                       + "date,expr,unit,dateFormat) function. "
-                                                                       + "First argument cannot be null"));
+        inputHandler.send(new Object[] { "WSO2", "2010-05-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, 2 });
         siddhiAppRuntime.shutdown();
     }
 
@@ -185,9 +187,6 @@ public class DateAddFunctionExtensionTestCase {
     public void dateAddFunctionExtension6() throws InterruptedException {
 
         log.info("DateAddFunctionExtensionTestCaseFourthArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = ""
@@ -203,34 +202,31 @@ public class DateAddFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
-                for (Event event : inEvents) {
                     count.incrementAndGet();
-                    AssertJUnit.assertEquals("2012-05-11 13:23:44", event.getData(1));
-                    AssertJUnit.assertEquals("2010-07-11 13:23:44", event.getData(2));
-                    AssertJUnit.assertEquals("1415699624000", event.getData(3));
-                    eventArrived = true;
+                    if (inEvents[0].getData(0).toString().equals("IBM")) {
+                        AssertJUnit.assertNull(inEvents[0].getData(1));
                     }
+                    if (inEvents[0].getData(0).toString().equals("WSO2")) {
+                        AssertJUnit.assertEquals("2012-05-11 13:23:44", inEvents[0].getData(1));
+                        AssertJUnit.assertEquals("2010-07-11 13:23:44", inEvents[0].getData(2));
+                        AssertJUnit.assertEquals("1415699624000", inEvents[0].getData(3));
+                    }
+                    eventArrived = true;
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", "2014-11-11 13:23:44", null, 1415692424000L, 2 });
-        inputHandler.send(new Object[] { "IBM", "2010-05-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, 2 });
-        SiddhiTestHelper.waitForEvents(100, 1, count, 60000);
-        AssertJUnit.assertEquals(1, count.get());
+        inputHandler.send(new Object[] { "WSO2", "2010-05-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, 2 });
+        SiddhiTestHelper.waitForEvents(100, 2, count, 60000);
+        AssertJUnit.assertEquals(2, count.get());
         AssertJUnit.assertTrue(eventArrived);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateAdd("
-                                                                       + "date,expr,unit,dateFormat) function. "
-                                                                       + "Fourth argument cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
     @Test
     public void dateAddFunctionExtension7() throws InterruptedException {
         log.info("DateAddFunctionExtensionTestCaseSecondArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = "" + "define stream inputStream (symbol string,dateValue string,dateFormat string,"
@@ -246,25 +242,24 @@ public class DateAddFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
-                for (Event event : inEvents) {
-                    count.incrementAndGet();
-                        AssertJUnit.assertEquals("2012-05-11 13:23:44", event.getData(1));
-                        AssertJUnit.assertEquals("2010-07-11 13:23:44", event.getData(2));
-                        AssertJUnit.assertEquals("1415699624000", event.getData(3));
-                        eventArrived = true;
+                if (inEvents[0].getData(0).toString().equals("IBM")) {
+                    AssertJUnit.assertNull(inEvents[0].getData(1));
                 }
+                if (inEvents[0].getData(0).toString().equals("WSO2")) {
+                    AssertJUnit.assertEquals("2012-05-11 13:23:44", inEvents[0].getData(1));
+                    AssertJUnit.assertEquals("2010-07-11 13:23:44", inEvents[0].getData(2));
+                    AssertJUnit.assertEquals("1415699624000", inEvents[0].getData(3));
+                }
+                count.incrementAndGet();
             }
         });
 
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", "2014-11-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, null });
-        inputHandler.send(new Object[] { "IBM", "2010-05-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, 2 });
-        SiddhiTestHelper.waitForEvents(100, 1, count, 60000);
-        AssertJUnit.assertEquals(1, count.get());
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateAdd("
-                                                                       + "date,expr,unit,dateFormat) function. "
-                                                                       + "Second argument cannot be null"));
+        inputHandler.send(new Object[] { "WSO2", "2010-05-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, 2 });
+        SiddhiTestHelper.waitForEvents(100, 2, count, 60000);
+        AssertJUnit.assertEquals(2, count.get());
         siddhiAppRuntime.shutdown();
     }
 
@@ -466,9 +461,6 @@ public class DateAddFunctionExtensionTestCase {
     public void dateAddFunctionExtension18() throws InterruptedException {
 
         log.info("DateAddFunctionExtensionTestCaseFirstArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = ""
@@ -483,6 +475,7 @@ public class DateAddFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
 
@@ -490,9 +483,6 @@ public class DateAddFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", "2014-11-11 13:23:44", "yyyy-MM-dd HH:mm:ss", null, 2 });
         inputHandler.send(new Object[] { "IBM", "2010-05-11 13:23:44", "yyyy-MM-dd HH:mm:ss", null, 2 });
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateAdd("
-                                                                       + "timestampInMilliseconds,expr,unit) function. "
-                                                                       + "First argument cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/time/DateDifferenceFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/time/DateDifferenceFunctionExtensionTestCase.java
@@ -251,9 +251,6 @@ public class DateDifferenceFunctionExtensionTestCase {
     public void dateDifferenceFunctionExtension8() throws InterruptedException {
 
         log.info("DateDifferenceFunctionExtensionFirstArgumetNullTestCase");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition =
@@ -269,6 +266,7 @@ public class DateDifferenceFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
 
@@ -283,10 +281,6 @@ public class DateDifferenceFunctionExtensionTestCase {
                 1415519624000L
         });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateDiff("
-                                                                       + "dateValue1,dateValue2,dateFormat1,"
-                                                                       + "dateFormat2) function. First argument "
-                                                                       + "cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
@@ -294,9 +288,6 @@ public class DateDifferenceFunctionExtensionTestCase {
     public void dateDifferenceFunctionExtension9() throws InterruptedException {
 
         log.info("DateDifferenceFunctionExtensionThirdArgumetNullTestCase");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition =
@@ -312,6 +303,7 @@ public class DateDifferenceFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
@@ -325,9 +317,6 @@ public class DateDifferenceFunctionExtensionTestCase {
                 1415519624000L
         });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateDiff(dateValue1,"
-                                                                       + "dateValue2,dateFormat1,dateFormat2) "
-                                                                       + "function. Third argument cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
@@ -335,9 +324,6 @@ public class DateDifferenceFunctionExtensionTestCase {
     public void dateDifferenceFunctionExtension10() throws InterruptedException {
 
         log.info("DateDifferenceFunctionExtensionSecondArgumetNullTestCase");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition =
@@ -353,6 +339,7 @@ public class DateDifferenceFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
                 eventArrived = true;
             }
         });
@@ -367,11 +354,6 @@ public class DateDifferenceFunctionExtensionTestCase {
                 "IBM", "2015-11-11 13:23:44", "yyyy-MM-dd HH:mm:ss", null, "yyyy-MM-dd HH:mm:ss", 1415692424000L,
                 1415519624000L
         });
-        Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateDiff("
-                                                                       + "dateValue1,dateValue2,dateFormat1,"
-                                                                       + "dateFormat2) function. Second argument "
-                                                                       + "cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/time/DateFormatFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/time/DateFormatFunctionExtensionTestCase.java
@@ -194,9 +194,6 @@ public class DateFormatFunctionExtensionTestCase {
     public void dateFormatFunctionExtension7() throws InterruptedException {
 
         log.info("DateFormatFunctionExtensionTestCaseFirstArgumentNul");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = "define stream inputStream (symbol string,"
@@ -213,15 +210,13 @@ public class DateFormatFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", null, "yyyy-MM-dd HH:mm:ss", 1415692424000L, "yyyy-MM-dd" });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateFormat(dateValue,"
-                                                                       + "dateTargetFormat,dateSourceFormat) function. "
-                                                                       + "First argument cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
@@ -229,9 +224,6 @@ public class DateFormatFunctionExtensionTestCase {
     public void dateFormatFunctionExtension8() throws InterruptedException {
 
         log.info("DateFormatFunctionExtensionTestCaseSecondArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = "define stream inputStream (symbol string,"
@@ -248,6 +240,7 @@ public class DateFormatFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
 
@@ -255,9 +248,6 @@ public class DateFormatFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", "2014:11-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, null });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateFormat(dateValue,"
-                                                                       + "dateTargetFormat,dateSourceFormat) function. "
-                                                                       + "Second argument cannot be null."));
         siddhiAppRuntime.shutdown();
     }
 
@@ -265,9 +255,6 @@ public class DateFormatFunctionExtensionTestCase {
     public void dateFormatFunctionExtension9() throws InterruptedException {
 
         log.info("DateFormatFunctionExtensionTestCaseThirdArgumentNul");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = "define stream inputStream (symbol string,"
@@ -284,15 +271,13 @@ public class DateFormatFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", "2014:11-11 13:23:44", null, 1415692424000L, "ss" });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:dateFormat(dateValue,"
-                                                                       + "dateTargetFormat,dateSourceFormat) function. "
-                                                                       + "Third argument cannot be null."));
         siddhiAppRuntime.shutdown();
     }
 
@@ -380,9 +365,6 @@ public class DateFormatFunctionExtensionTestCase {
     public void dateFormatFunctionExtension14() throws InterruptedException {
 
         log.info("DateFormatFunctionExtensionTestCaseFirstArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = "define stream inputStream (symbol string,"
@@ -398,6 +380,7 @@ public class DateFormatFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
 
@@ -405,9 +388,6 @@ public class DateFormatFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", "2014-11-11 13:23:44", "yyyy-MM-dd HH:mm:ss", null, "ss" });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to dateFormat("
-                                                                       + "timestampInMilliseconds,dateTargetFormat) "
-                                                                       + "function. First argument cannot be null."));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/time/DateSubFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/time/DateSubFunctionExtensionTestCase.java
@@ -196,9 +196,6 @@ public class DateSubFunctionExtensionTestCase {
     public void dateSubFunctionExtension7() throws InterruptedException {
 
         log.info("DateSubFunctionExtensionTestCaseFirstArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = ""
@@ -215,6 +212,7 @@ public class DateSubFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
 
@@ -222,9 +220,6 @@ public class DateSubFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", null, "yyyy-MM-dd HH:mm:ss", 1415692424000L, 2 });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to str:dateSub(date,expr,unit,"
-                                                                       + "dateFormat) function. First argument "
-                                                                       + "cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
@@ -232,9 +227,6 @@ public class DateSubFunctionExtensionTestCase {
     public void dateSubFunctionExtension8() throws InterruptedException {
 
         log.info("DateSubFunctionExtensionTestCaseFourthArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = ""
@@ -251,6 +243,7 @@ public class DateSubFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
@@ -258,9 +251,6 @@ public class DateSubFunctionExtensionTestCase {
         inputHandler.send(new Object[] { "IBM", "2014-11-11 13:23:44", null, 1415692424000L, 2 });
         inputHandler.send(new Object[] { "IBM", "2015-11-11 13:23:44", null, 1415692424000L, 2 });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to str:dateSub(date,expr,unit,"
-                                                                       + "dateFormat) function. Fourth argument "
-                                                                       + "cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
@@ -268,9 +258,6 @@ public class DateSubFunctionExtensionTestCase {
     public void dateSubFunctionExtension9() throws InterruptedException {
 
         log.info("DateSubFunctionExtensionTestCaseSecondArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = ""
@@ -287,15 +274,13 @@ public class DateSubFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", "2014-11-11 13:23:44", "yyyy-MM-dd HH:mm:ss", 1415692424000L, null });
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to str:dateSub(date,expr,unit,"
-                                                                       + "dateFormat) function. Second argument cannot "
-                                                                       + "be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/time/ExtractAttributesFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/time/ExtractAttributesFunctionExtensionTestCase.java
@@ -197,9 +197,6 @@ public class ExtractAttributesFunctionExtensionTestCase {
     public void extractAttributesFunctionExtension7() throws InterruptedException {
 
         log.info("ExtractAttributesFunctionExtensionSecondArgumentNullTestCase");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = ""
@@ -215,15 +212,13 @@ public class ExtractAttributesFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{"IBM", null, "yyyy-MM-dd hh:mm:ss", System.currentTimeMillis()});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:extract(unit,dateValue,"
-                + "dateFormat) function. Second argument cannot"
-                + " be null"));
         siddhiAppRuntime.shutdown();
     }
 
@@ -231,9 +226,6 @@ public class ExtractAttributesFunctionExtensionTestCase {
     public void extractAttributesFunctionExtension8() throws InterruptedException {
 
         log.info("ExtractAttributesFunctionExtensionThirdArgumentNullTestCase");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition = ""
@@ -249,15 +241,13 @@ public class ExtractAttributesFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{"IBM", "2014:3-11 02:23:44", null, System.currentTimeMillis()});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:extract(unit,dateValue,"
-                + "dateFormat) function. Third argument cannot "
-                + "be null"));
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/execution/time/ExtractDateFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/time/ExtractDateFunctionExtensionTestCase.java
@@ -161,9 +161,6 @@ public class ExtractDateFunctionExtensionTestCase {
     public void extractDateFunctionExtension6() throws InterruptedException {
 
         log.info("ExtractDateFunctionExtensionTestCaseFirstArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition =
@@ -176,14 +173,13 @@ public class ExtractDateFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", "2014-11-11 13:23:44.657", null });
         siddhiAppRuntime.shutdown();
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:date(dateValue,dateFormat)"
-                                                                       + " function. First argument cannot be null"));
 
     }
 
@@ -191,9 +187,6 @@ public class ExtractDateFunctionExtensionTestCase {
     public void extractDateFunctionExtension7() throws InterruptedException {
 
         log.info("ExtractDateFunctionExtensionTestCaseSecondArgumentNull");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String inStreamDefinition =
@@ -206,6 +199,7 @@ public class ExtractDateFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
 
@@ -213,7 +207,5 @@ public class ExtractDateFunctionExtensionTestCase {
         siddhiAppRuntime.start();
         inputHandler.send(new Object[] { "IBM", null, "yyyy-MM-dd HH:mm:ss" });
         siddhiAppRuntime.shutdown();
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:date(dateValue,dateFormat)"
-                                                                       + " function. Second argument cannot be null"));
     }
 }

--- a/component/src/test/java/io/siddhi/extension/execution/time/TimestampInMillisecondsFunctionExtensionTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/time/TimestampInMillisecondsFunctionExtensionTestCase.java
@@ -299,9 +299,6 @@ public class TimestampInMillisecondsFunctionExtensionTestCase {
     public void timestampInMillisecondsWithAllArgumentsFunctionExtension8() throws InterruptedException {
 
         log.info("TimestampInMillisecondsWithAllArgumentsFunctionExtensionFirstArgumentNullTestCase");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         String dateTime = "2007-11-30 10:30:19.000";
         final Timestamp timestamp = Timestamp.valueOf(dateTime);
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -317,15 +314,13 @@ public class TimestampInMillisecondsFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{"IBM", null, 100L});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:timestampInMilliseconds("
-                + "dateValue,dateFormat) function. First "
-                + "argument cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 
@@ -333,9 +328,6 @@ public class TimestampInMillisecondsFunctionExtensionTestCase {
     public void timestampInMillisecondsWithAllArgumentsFunctionExtension9() throws InterruptedException {
 
         log.info("TimestampInMillisecondsWithAllArgumentsFunctionExtensionSecondArgumentNullTestCase");
-        UnitTestAppender appender = new UnitTestAppender();
-        log = Logger.getLogger(StreamJunction.class);
-        log.addAppender(appender);
         String dateTime = "2007-11-30 10:30:19.000";
         final Timestamp timestamp = Timestamp.valueOf(dateTime);
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -351,15 +343,13 @@ public class TimestampInMillisecondsFunctionExtensionTestCase {
             @Override
             public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
                 EventPrinter.print(timeStamp, inEvents, removeEvents);
+                AssertJUnit.assertNull(inEvents[0].getData(1));
             }
         });
         InputHandler inputHandler = siddhiAppRuntime.getInputHandler("inputStream");
         siddhiAppRuntime.start();
         inputHandler.send(new Object[]{"IBM", 700f, null});
         Thread.sleep(100);
-        AssertJUnit.assertTrue(appender.getMessages().contains("Invalid input given to time:timestampInMilliseconds("
-                + "dateValue,dateFormat) function. First "
-                + "argument cannot be null"));
         siddhiAppRuntime.shutdown();
     }
 }


### PR DESCRIPTION
## Purpose
Fix https://github.com/siddhi-io/siddhi-execution-time/issues/58

## Goals
Avoid unnecessory error logs in the console.

## Approach
When the RESET event goes through the execute() method, some of the elements in the data array could be null. When this happens, the execute() method should return null; rather than throwing a SiddhiAppRuntimeException. When the execute() method returns null, Siddhi properly handles it. This is the same   behaviour that is there in the expression executors in the Siddhi core (For example, refer AddExpressionExecutorInt class in Siddhi core).

## Documentation
N/A as this is a bug fix.

## Certification
N/A as this is a bug fix.

## Automation tests
 - Unit tests 
   > available
 - Integration tests
   > not available

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Migrations (if applicable)
The functions listed under this extension will now return null, when a null input is given.

## Test environment
Mac OS 10.13.1 (17B1003)
java version "1.8.0_171"
Java(TM) SE Runtime Environment (build 1.8.0_171-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.171-b11, mixed mode)